### PR TITLE
Add Blank Issue Template & Config

### DIFF
--- a/.github/ISSUE_TEMPLATES/blank.yml
+++ b/.github/ISSUE_TEMPLATES/blank.yml
@@ -1,0 +1,8 @@
+name: "📝 Blank Issue"
+description: "Create a blank issue without pre-filled template"
+title: "[ISSUE] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: "Describe your issue here."

--- a/.github/ISSUE_TEMPLATES/bug.yml
+++ b/.github/ISSUE_TEMPLATES/bug.yml
@@ -1,0 +1,47 @@
+name: "🐛 Bug Report"
+description: "Report a bug in the Student Risk Analyzer system"
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide detailed information about the bug so we can reproduce it and fix it.
+
+  - type: input
+    id: steps
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Step by step instructions to reproduce the bug"
+      placeholder: "1. Run app_student.py\n2. Log in as student\n3. Observe error"
+      required: true
+
+  - type: input
+    id: expected
+    attributes:
+      label: "Expected Behavior"
+      description: "What you expected to happen"
+      placeholder: "Student dashboard should load"
+      required: true
+
+  - type: input
+    id: actual
+    attributes:
+      label: "Actual Behavior"
+      description: "What actually happened"
+      placeholder: "Application crashes with FileNotFoundError"
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Affected Component"
+      description: "Which part of the repo is affected?"
+      options:
+        - "Data Generator"
+        - "Student Dashboard"
+        - "Mentor Dashboard"
+        - "Risk Engine"
+        - "App Manager"
+        - "Other"
+      required: true

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Support"
+    url: "https://github.com/abhishekkumar177/sih_idearepo/issues"
+    about: "Create an issue if you need help"

--- a/.github/ISSUE_TEMPLATES/enhancement.yml
+++ b/.github/ISSUE_TEMPLATES/enhancement.yml
@@ -1,0 +1,22 @@
+name: "🚀 Enhancement"
+description: "Suggest an improvement to the existing functionality"
+title: "[ENHANCEMENT] "
+labels: ["enhancement"]
+body:
+  - type: input
+    id: enhancement_description
+    attributes:
+      label: "Enhancement Description"
+      description: "Describe the improvement you want to see"
+      placeholder: "Add a filter for overdue fees in mentor dashboard"
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low
+      required: true

--- a/.github/ISSUE_TEMPLATES/refactor.yml
+++ b/.github/ISSUE_TEMPLATES/refactor.yml
@@ -1,0 +1,22 @@
+name: "♻️ Refactor"
+description: "Suggest refactoring of code for readability, performance, or structure"
+title: "[REFACTOR] "
+labels: ["refactor"]
+body:
+  - type: input
+    id: refactor_description
+    attributes:
+      label: "Refactor Description"
+      description: "Which part of the code should be refactored?"
+      placeholder: "Refactor risk_engine.py for modularity and testing"
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priority"
+      options:
+        - High
+        - Medium
+        - Low
+      required: true

--- a/.github/pull_request_template.yml
+++ b/.github/pull_request_template.yml
@@ -1,0 +1,36 @@
+name: "🔀 Pull Request"
+description: "Template for pull requests in Student Risk Analyzer"
+title: "[PR] "
+labels: ["pr"]
+body:
+  - type: input
+    id: pr_description
+    attributes:
+      label: "Pull Request Description"
+      description: "Describe what changes you made"
+      placeholder: "Fixed bug in attendance calculation or added a new feature"
+      required: true
+
+  - type: checklist
+    id: checklist
+    attributes:
+      label: "Checklist"
+      options:
+        - "Code runs without errors"
+        - "Tested locally"
+        - "Updated documentation if needed"
+        - "Followed coding standards"
+        - "Added comments where necessary"
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Affected Component"
+      options:
+        - "Data Generator"
+        - "Student Dashboard"
+        - "Mentor Dashboard"
+        - "Risk Engine"
+        - "App Manager"
+        - "Other"
+      required: true


### PR DESCRIPTION

## Description
Added a **Blank Issue** template for the repository.  
- Provides a simple template for any custom or uncategorized issues.  
- Ensures contributors can create issues that do not fit predefined categories.

## Type of Change
- [x] Enhancement / New Feature

## Affected Components
- [x] .github/ISSUE_TEMPLATE/blank.yml

## Checklist
- [x] Verified template appears correctly in GitHub UI
- [x] Documentation updated if needed

## Related Issue
- Closes #20 
